### PR TITLE
Enhancements

### DIFF
--- a/json_array.tps
+++ b/json_array.tps
@@ -7,7 +7,8 @@ TYPE json_array IS OBJECT
 	--	Constructors
 	CONSTRUCTOR FUNCTION json_array(self IN OUT NOCOPY json_array) RETURN self AS result,
 	CONSTRUCTOR FUNCTION json_array(SELF IN OUT NOCOPY json_array, theData IN json_value) RETURN SELF AS result,
-
+	CONSTRUCTOR FUNCTION json_array(SELF IN OUT NOCOPY json_array, theJSONString IN CLOB) RETURN SELF AS result,
+	
 	--	Member setter methods
 	MEMBER PROCEDURE append(self IN OUT NOCOPY json_array),
 	MEMBER PROCEDURE append(self IN OUT NOCOPY json_array, theValue IN VARCHAR2),
@@ -27,6 +28,7 @@ TYPE json_array IS OBJECT
 
 	--	Output methods
 	MEMBER PROCEDURE to_clob(SELF IN json_array, theLobBuf IN OUT NOCOPY CLOB, theEraseLob BOOLEAN DEFAULT TRUE),
+	MEMBER FUNCTION to_string (SELF IN json_array) RETURN VARCHAR2,
 	MEMBER PROCEDURE htp(SELF IN json_array, theJSONP IN VARCHAR2 DEFAULT NULL)
 );
 /

--- a/json_object.tpb
+++ b/json_object.tpb
@@ -187,6 +187,30 @@ BEGIN
 END to_clob;
 
 ----------------------------------------------------------
+--	to_string
+--
+MEMBER FUNCTION to_string (SELF IN json_object) RETURN VARCHAR2
+IS
+	aLob	CLOB	:=	empty_clob();
+	theString VARCHAR2(32767) := '';
+	theLength  BINARY_INTEGER;
+    e_too_small EXCEPTION; -- ORA-06502: PL/SQL: numeric or value error
+    PRAGMA EXCEPTION_INIT( e_too_small, -06502);
+BEGIN
+	dbms_lob.createtemporary(aLob, TRUE);
+	self.to_clob(aLob);
+	theLength := dbms_lob.getlength(aLob);
+	IF theLength <= 32767 THEN
+		theString := dbms_lob.substr(aLob, 32767, 1); 
+	END IF;
+	dbms_lob.freetemporary(aLob);
+	IF theLength > 32767 THEN
+		RAISE e_too_small;
+	END IF;
+	RETURN theString;
+END to_string;
+
+----------------------------------------------------------
 --	htp
 --
 MEMBER PROCEDURE htp(SELF IN json_object, theJSONP IN VARCHAR2 DEFAULT NULL)

--- a/json_object.tps
+++ b/json_object.tps
@@ -100,6 +100,7 @@ TYPE json_object IS OBJECT
 
 	--	Output methods
 	MEMBER PROCEDURE to_clob(SELF IN json_object, theLobBuf IN OUT NOCOPY CLOB, theEraseLob BOOLEAN DEFAULT TRUE),
+	MEMBER FUNCTION to_string (SELF IN json_object) RETURN VARCHAR2,
 	MEMBER PROCEDURE htp(SELF IN json_object, theJSONP IN VARCHAR2 DEFAULT NULL)
 );
 /

--- a/json_parser.pks
+++ b/json_parser.pks
@@ -49,7 +49,7 @@ json_strict BOOLEAN NOT NULL := FALSE;
 --	GLOBAL PUBLIC MODULES
 ----------------------------------------------------------
 
-FUNCTION parser(str CLOB) RETURN json_nodes;
+FUNCTION parser(str CLOB, type_name CHAR := '{') RETURN json_nodes;
 FUNCTION parse_list(str CLOB) RETURN json_nodes;
 FUNCTION parse_any(str CLOB) RETURN json_nodes;
 


### PR DESCRIPTION
we needed the ability to work with JSON-arrays generated and consumed by google-gson (A Java library to convert JSON to Java objects and vice-versa) in stored procedures, so we decided to enhance the json_array type.
As we handle small objects we added the "to_string" method to the json_array and json_object to encapsulate the CLOB-handling, but we are not sure about "the right" way to avoid invalid return values. 
